### PR TITLE
Fix bug with controller search and indexing

### DIFF
--- a/source/Windows.Devices.Pwm/PwmController.cs
+++ b/source/Windows.Devices.Pwm/PwmController.cs
@@ -24,12 +24,13 @@ namespace Windows.Devices.Pwm
 
         internal PwmController(string controller)
         {
+            // the Pwm id is an ASCII string with the format 'PWMn'
+            // need to grab 'n' from the string and convert that to the integer value from the ASCII code (do this by subtracting 48 from the char value)
+            _controllerId = controller[3] - '0';
+
             // check if this controller is already opened
-            if (!PwmControllerManager.ControllersCollection.Contains(controller))
+            if (!PwmControllerManager.ControllersCollection.Contains(_controllerId))
             {
-                // the Pwm id is an ASCII string with the format 'PWMn'
-                // need to grab 'n' from the string and convert that to the integer value from the ASCII code (do this by subtracting 48 from the char value)
-                _controllerId = controller[3] - '0';
 
                 _actualFrequency = 0.0;
                 _pwmTimer = controller;
@@ -121,10 +122,14 @@ namespace Windows.Devices.Pwm
 
             if (controllers.Length > 0)
             {
-                if (PwmControllerManager.ControllersCollection.Contains(controllers[0]))
+                // the Pwm id is an ASCII string with the format 'PWMn'
+                // need to grab 'n' from the string and convert that to the integer value from the ASCII code (do this by subtracting 48 from the char value)
+                var controllerId = controllers[0][3] - '0';
+
+                if (PwmControllerManager.ControllersCollection.Contains(controllerId))
                 {
                     // controller is already open
-                    return (PwmController)PwmControllerManager.ControllersCollection[controllers[0]];
+                    return (PwmController)PwmControllerManager.ControllersCollection[controllerId];
                 }
                 else
                 {


### PR DESCRIPTION
## Description
- Controller collection is now searched with the correct index.

## Motivation and Context
- Collection was being searched sometimes with the full AQS and other with the index. Now it's consistently stored and searched with index only.

## How Has This Been Tested?<!-- (if applicable) -->
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots<!-- (if appropriate): -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Improvement (non-breaking change that improves a feature, code or algorithm)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Signed-off-by: José Simões <jose.simoes@eclo.solutions>
